### PR TITLE
Bump @aguycalled/bitcore-p2p version

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@aguycalled/bitcore-mnemonic": "^1.5.1",
-    "@aguycalled/bitcore-p2p": "^5.0.10",
+    "@aguycalled/bitcore-p2p": "^5.0.11",
     "@arelstone/react-native-swipe-button": "^0.1.0",
     "@eva-design/eva": "^2.1.1",
     "@gorhom/bottom-sheet": "^4.1.5",


### PR DESCRIPTION
Bumps the pkg version to solve the random `Error: Socket is not connected.` exceptions.